### PR TITLE
Do not encode URIs twice.

### DIFF
--- a/api/src/main/java/mb/resource/classloader/ClassLoaderResource.java
+++ b/api/src/main/java/mb/resource/classloader/ClassLoaderResource.java
@@ -4,13 +4,11 @@ import mb.resource.ReadableResource;
 import mb.resource.ResourceRuntimeException;
 import mb.resource.fs.FSResource;
 import mb.resource.hierarchical.HierarchicalResource;
-import mb.resource.hierarchical.HierarchicalResourceAccess;
 import mb.resource.hierarchical.HierarchicalResourceType;
 import mb.resource.hierarchical.SegmentsPath;
 import mb.resource.hierarchical.SegmentsResource;
 import mb.resource.hierarchical.match.ResourceMatcher;
 import mb.resource.hierarchical.walk.ResourceWalker;
-import mb.resource.util.UriEncode;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.File;
@@ -251,6 +249,7 @@ public class ClassLoaderResource extends SegmentsResource<ClassLoaderResource> i
         return locations;
     }
 
+    // We operate under the expectation that `url` is encoded.
     private void processLocationUrl(URL url, ClassLoaderResourceLocations locations) {
         final String protocol = url.getProtocol();
         if("file".equals(protocol)) {
@@ -273,7 +272,7 @@ public class ClassLoaderResource extends SegmentsResource<ClassLoaderResource> i
                 pathInJarFile = urlPath.substring(exclamationMarkIndex + 1); // + 1 to skip past '!'
             }
             try {
-                final FSResource jarFile = new FSResource(UriEncode.encodeToUri(jarFilePath));
+                final FSResource jarFile = new FSResource(new URI(jarFilePath));
                 locations.jarFiles.add(new JarFileWithPath(jarFile, pathInJarFile));
             } catch(URISyntaxException e) {
                 throw new ResourceRuntimeException("Could not add class loader resource location for '" + url + "'; conversion of nested path '" + jarFilePath + "' to an URI failed", e);

--- a/api/src/main/java/mb/resource/classloader/ClassLoaderUrlResolver.java
+++ b/api/src/main/java/mb/resource/classloader/ClassLoaderUrlResolver.java
@@ -7,7 +7,8 @@ import java.net.URL;
 public interface ClassLoaderUrlResolver {
     /**
      * Attempt to resolve given {@code url} into one that {@link ClassLoaderResource#getLocations} understands. Returns
-     * {@code null} if the {@code url} cannot be resolved.
+     * {@code null} if the {@code url} cannot be resolved. Note that any special characters in the returned URL must
+     * be encoded using standard URL encoding (e.g. ' ' -> '%20') in order to properly support all paths.
      *
      * @param url {@link URL} to be resolved.
      * @return Resolved {@link URL} or {@code null}.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("org.metaborg.gradle.config.root-project") version "0.4.4"
+  id("org.metaborg.gradle.config.root-project") version "0.4.6"
   id("org.metaborg.gitonium") version "0.1.4"
 }
 


### PR DESCRIPTION
This fixes some tests when run in a directory with a space or some other special character.