### PR TITLE
Fix incorrect URI creation on Windows

### DIFF
--- a/api/src/main/java/mb/resource/fs/FSResourceRegistry.java
+++ b/api/src/main/java/mb/resource/fs/FSResourceRegistry.java
@@ -45,7 +45,7 @@ public class FSResourceRegistry implements ResourceRegistry {
             throw new ResourceRuntimeException("Qualifier of '" + keyStr + "' does not match qualifier '" + qualifier + "' of this resource registry");
         }
         try {
-            return new FSResource(new URI(keyStr.getId()));
+            return new FSResource(new URI(SeparatorUtil.convertCurrentToUnixSeparator(keyStr.getId())));
         } catch(URISyntaxException e) {
             throw new ResourceRuntimeException("Could not create FSPath from '" + keyStr + "', URI parsing failed", e);
         }


### PR DESCRIPTION
metaborg/devenv doesn't currently build on Windows: `keyStr` will be something like `C:\...`, which isn't a valid URL. This changes it to be a proper file URL and should work on all platforms (although I have not verified this; if you could confirm this works that'd be great).